### PR TITLE
Add block index option `i`

### DIFF
--- a/Gui/Dialogs.cs
+++ b/Gui/Dialogs.cs
@@ -351,7 +351,7 @@ namespace Telescope.Gui
             Application.Run(dialog);
         }
 
-        private static void IndexSearchAction(Views views, string searchIndex)
+        public static void IndexSearchAction(Views views, string searchIndex)
         {
             var result = Int64.TryParse(searchIndex, out long index);
             if (result)

--- a/Gui/Dialogs.cs
+++ b/Gui/Dialogs.cs
@@ -353,7 +353,7 @@ namespace Telescope.Gui
 
         public static void IndexSearchAction(Views views, string searchIndex)
         {
-            var result = Int64.TryParse(searchIndex, out long index);
+            var result = long.TryParse(searchIndex, out var index);
             if (result)
             {
                 try

--- a/Program.cs
+++ b/Program.cs
@@ -17,7 +17,9 @@ namespace Telescope
 
         public void Run(
             [Option('p', Description = "Path to chain storage with its scheme specified.")]
-            string path)
+            string path,
+            [Option('i', Description = "Index of the block to show.")]
+            long blockIndex = 0)
         {
             Uri uri = new Uri($"{path}");
 
@@ -29,6 +31,10 @@ namespace Telescope
             Views views = new Views(blockChain);
             Menus menus = new Menus(views);
             views.TopView.Add(menus.MenuBar);
+            if (blockIndex != 0)
+            {
+                Dialogs.IndexSearchAction(views, blockIndex.ToString());    
+            }
 
             Application.Run(views.TopView);
             Application.Shutdown();

--- a/Program.cs
+++ b/Program.cs
@@ -19,7 +19,7 @@ namespace Telescope
             [Option('p', Description = "Path to chain storage with its scheme specified.")]
             string path,
             [Option('i', Description = "Index of the block to show.")]
-            long blockIndex = 0)
+            long? blockIndex = null)
         {
             Uri uri = new Uri($"{path}");
 
@@ -31,9 +31,9 @@ namespace Telescope
             Views views = new Views(blockChain);
             Menus menus = new Menus(views);
             views.TopView.Add(menus.MenuBar);
-            if (blockIndex != 0)
+            if (blockIndex is { } bi)
             {
-                Dialogs.IndexSearchAction(views, blockIndex.ToString());    
+                Dialogs.IndexSearchAction(views, bi.ToString());    
             }
 
             Application.Run(views.TopView);


### PR DESCRIPTION
Now we can use option `i` when we needed to show specific index of block on first view.

```bash
dotnet run -- -p "<store-scheme>://<store-path>" -i {block index to show on first view}
```
