### PR TITLE
✨ Added state check when starting Telescope

### DIFF
--- a/WrappedBlockChain.cs
+++ b/WrappedBlockChain.cs
@@ -80,5 +80,20 @@ namespace Telescope
                 ? new WrappedState(s)
                 : throw new NullReferenceException("Failed to fetch state.");
         }
+
+        public bool HasState(long index)
+        {
+            // NOTE: Better way would be to check ITrie.Recroded, but
+            // BlockChain does not allow direct access to IStateStore.
+            try
+            {
+                _ = _blockChain.GetAccountState(_blockChain[index].StateRootHash);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #32.

As written in the comment, this makes some assumptions (as iterating the chain in its entirety would take too much time) on how states are stored. 

- This PR assumes blocks having states must come after blocks not having states.
- This PR **does not assume** that there must be at least one block (the tip of the blockchain) with its associated state.

In the picture below, blocks are rendered brighter in the blockchain view if it has a state.

![telescope-state-check](https://github.com/planetarium/Telescope/assets/25877496/fcf0ab50-7311-4b4f-b1ba-72b93b2b31da)
